### PR TITLE
Correct year typo (1947 -> 1847)

### DIFF
--- a/_pug/utah.pug
+++ b/_pug/utah.pug
@@ -14,7 +14,7 @@ block content
     p In prepration for the 1903 St. Louis World’s Fair, the Utah Daughters of the American Revolution (DAR) created an unofficial flag. It was embroidered by Agnes Frenelius of Zion’s Cooperative Mercantile Institution.
     p The flag, a field of blue with the coat of arms in white, was officially adopted March 9, 1911.
     p In 1913, a full color version was adopted.
-    p In 1922, Dollie McMonegal embroidered the flag with an error (the year 1947 was moved outside of the shield). This was copied and reproduced for years, until the error was noticed by vexillologist John M. Hartvigsen in the 1980s.
+    p In 1922, Dollie McMonegal embroidered the flag with an error (the year 1847 was moved outside of the shield). This was copied and reproduced for years, until the error was noticed by vexillologist John M. Hartvigsen in the 1980s.
     p It wasn’t until February 2011 that Utah adopted a concurrent resolution requiring flag makers to fix the mistake.
 
   .guide


### PR DESCRIPTION
I was just reading through the page and I think I noticed a typo in the paragraph discussing the 1922 McMonegal flag. It says that the year 1947 was accidentally embroidered under the coat, but further down in the document an image of the McMonegal flag is shown with the year 1847 under the coat:

![](https://usflags.design/assets/images/flag-utah-1913-2011.jpg)